### PR TITLE
Remove Polyfill JavaScript

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,6 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/mathjax.js #imo not needed, for math equations, no javascripts folder either
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js #imo not needed, for math equations
   - https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js
 


### PR DESCRIPTION
This PR removes Polyfill as extra Javascript from the Knowledge Center documentation.
The reason to do this is that we have recently noticed that in some parts of the documentation that makes use of Polyfill as extra Javascript, a pop up was visible asking for a username and password.

Polyfill has impacted different websites and https://github.com/squidfunk/mkdocs-material/issues/7295 from mkdocs-material a couple of years ago